### PR TITLE
Update Ubuntu to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL mainainer="gdavid0510@gmail.com"
 
 # Install required packages 


### PR DESCRIPTION
The latest Gridcoin release 5.0.2 was not published for 18.04. An update to Ubuntu 20.04 fixes this.